### PR TITLE
Added job timeout

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -18,6 +18,9 @@ jobs:
         BUILD_TARGET: [release]
         os: [ubuntu-22.04, ubuntu-24.04, windows-2022, windows-2025]
 
+    # Monitor this time limit as time goes on.
+    timeout-minutes: 20
+
     steps:
       - uses: actions/checkout@v4
       - name: Build


### PR DESCRIPTION
For some reason a Windows job had been running for 24 hours, which will burn through my GitHub cash pretty quick if it keeps happening.